### PR TITLE
배포 빌드 에러 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-unused-imports": "3.1.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "kakao.maps.d.ts": "^0.1.40",
     "prettier": "^3.3.3",
     "storybook": "^7.5.2",
     "ts-node": "^10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
+      kakao.maps.d.ts:
+        specifier: ^0.1.40
+        version: 0.1.40
       prettier:
         specifier: ^3.3.3
         version: 3.4.2

--- a/src/components/RunningLevelModal/index.tsx
+++ b/src/components/RunningLevelModal/index.tsx
@@ -15,6 +15,7 @@ interface RunningLevelProps {
 const RunningLevelModal = ({ percent }: RunningLevelProps) => {
   const { LV } = useLVStore();
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const getLVText = (value: number): string[] => {


### PR DESCRIPTION
## 개요 💡

배포시 생기는 빌드에러를 해결하였습니다

## 작업내용 ⌨️

- 사용하지 않는 변수 주석처리
- kakao.maps.d.ts 의존성 추가